### PR TITLE
Use ImageFileDirectory_v2 in Image.Exif

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -219,7 +219,7 @@ class TestFileJpeg(PillowTestCase):
             gps_index = 34853
             expected_exif_gps = {
                 0: b"\x00\x00\x00\x01",
-                2: (4294967295, 1),
+                2: 4294967295,
                 5: b"\x01",
                 30: 65535,
                 29: "1999:99:99 99:99:99",
@@ -241,7 +241,7 @@ class TestFileJpeg(PillowTestCase):
             36867: "2099:09:29 10:10:10",
             34853: {
                 0: b"\x00\x00\x00\x01",
-                2: (4294967295, 1),
+                2: 4294967295,
                 5: b"\x01",
                 30: 65535,
                 29: "1999:99:99 99:99:99",
@@ -253,11 +253,11 @@ class TestFileJpeg(PillowTestCase):
             271: "Make",
             272: "XXX-XXX",
             305: "PIL",
-            42034: ((1, 1), (1, 1), (1, 1), (1, 1)),
+            42034: (1,1,1,1),
             42035: "LensMake",
             34856: b"\xaa\xaa\xaa\xaa\xaa\xaa",
-            282: (4294967295, 1),
-            33434: (4294967295, 1),
+            282: 4294967295,
+            33434: 4294967295,
         }
 
         with Image.open("Tests/images/exif_gps.jpg") as im:
@@ -637,6 +637,19 @@ class TestFileJpeg(PillowTestCase):
             # This should return the default, and not a SyntaxError or
             # OSError for unidentified image.
             self.assertEqual(im.info.get("dpi"), (72, 72))
+
+    def test_exif_x_resolution(self, tmp_path):
+        with Image.open("Tests/images/flower.jpg") as im:
+            exif = im.getexif()
+            assert exif[282] == 180
+
+            out = str(tmp_path / "out.jpg")
+            with pytest.warns(None) as record:
+                im.save(out, exif=exif)
+            assert len(record) == 0
+
+        with Image.open(out) as reloaded:
+            assert reloaded.getexif()[282] == 180
 
     def test_invalid_exif_x_resolution(self):
         # When no x or y resolution is defined in EXIF

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -3188,7 +3188,7 @@ class Exif(MutableMapping):
 
     def _fixup(self, value):
         try:
-            if len(value) == 1 and not isinstance(value, dict):
+            if len(value) == 1 and isinstance(value, tuple):
                 return value[0]
         except Exception:
             pass
@@ -3209,7 +3209,7 @@ class Exif(MutableMapping):
         else:
             from . import TiffImagePlugin
 
-            info = TiffImagePlugin.ImageFileDirectory_v1(self.head)
+            info = TiffImagePlugin.ImageFileDirectory_v2(self.head)
             info.load(self.fp)
             return self._fixup_dict(info)
 
@@ -3234,7 +3234,7 @@ class Exif(MutableMapping):
         # process dictionary
         from . import TiffImagePlugin
 
-        self._info = TiffImagePlugin.ImageFileDirectory_v1(self.head)
+        self._info = TiffImagePlugin.ImageFileDirectory_v2(self.head)
         self.endian = self._info._endian
         self.fp.seek(self._info.next)
         self._info.load(self.fp)


### PR DESCRIPTION
Fixes https://github.com/python-pillow/Pillow/pull/4637

Changes proposed in this pull request:

copied from https://github.com/python-pillow/Pillow/pull/4637